### PR TITLE
Add support for PDF generation

### DIFF
--- a/_layouts/pdf.html
+++ b/_layouts/pdf.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <title>{{ site.title }}</title>
+    <meta name="robots" content="noindex">
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="stylesheet" href="https://use.typekit.net/xtb6utt.css">
+    <link rel="stylesheet" type="text/css" media="all" href="{{ '/assets/css/print.css?v=' | append: site.github.build_revision | relative_url }}">
+  </head>
+  <body>
+    <main id="main_content" class="pdf-content">
+      <h1 style="text-align: center;">{{ site.title }}</h1>
+
+      <!-- Index page content -->
+      {%- assign homepage = site.pages | where:'title', 'Homepage' | first -%}
+      {{ homepage.content | markdownify }}
+
+      <!-- Content Sections -->
+      {%- assign sections = site.collections | sort: 'section_order' -%}
+      {%- for collection in sections -%}
+        {%- if collection.label != 'posts' -%}
+          <section>
+            {% assign items = collection.docs | sort: "order" %}
+            {% for item in items %}
+              {%- if item == items.first -%}
+                <h1>
+                  <span>{{ collection.section_order }}</span>
+                  {{ item.title }}
+                </h1>
+              {%- else -%}
+                <h2>
+                  <span>{{ collection.section_order}}.{{forloop.index | minus: 1}}</span>
+                  {{ item.title }}
+                </h2>
+              {%- endif -%}
+              {{ item.content | markdownify }}
+            {% endfor %}
+          </section>
+        {%- endif -%}
+      {%- endfor -%}
+      <section>
+        <a href="{{site.url}}">{{site.url}}</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -1,7 +1,52 @@
+html {
+  font-size: 14px;
+}
+
 header, nav, footer, #skip_nav_link {
   display: none;
 }
 
 main {
   padding: 1em;
+}
+
+.pdf-content {
+  font-family: 'Times New Roman', serif;
+
+  section {
+    border-bottom: 1px solid gray;
+
+    > * {
+      margin-left: 30px;
+    }
+
+    > h1 {
+      margin-left: 0;
+    }
+
+    h1, h2 {
+      span {
+        display: inline-block;
+        font-size: 1em;
+        margin-right: .2em;
+        padding: 0 .5em;
+      }
+    }
+    h1 span {
+      background-color: #f2f2f2;
+    }
+    h2 span {
+      border-left: 3px solid lightgray;
+    }
+    &:last-child {
+      border-bottom: none;
+      padding-top: 2em;
+      text-align: center;
+    }
+  }
+
+  li {
+    margin-left: 1em;
+  }
+
 }


### PR DESCRIPTION
This layout file and corresponding CSS compiles a site's homepage content and all sections and sub-sections into a single HTML page, accessible at `/pdf` off the baseurl (for example, https://ops.palmereventscenter.com/pdf), which inherits print-optimized styles. That page can be provided to an HTML-to-PDF converter (either desktop, command-line, or web-based) to generate a single PDF of the entire site.

**Required for maintainers:**  
You must add `pdf.md` to the root of your project (at the same level as `index.md`). Do not place any content or frontmatter in the file.