### PR TITLE
Rename Search ID in theme to avoid conflict

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,5 +1,5 @@
 {%- if site.searchable -%}
-<div id="search">
+<div id="ops_search">
   <div>
     <input type="text" id="search-input" placeholder="Search" aria-label="Search the site">
     <ul id="results-container"></ul>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -118,7 +118,7 @@ footer {
   width:1px;
 }
 
-#search {
+#ops_search {
   max-width: 300px;
   position: absolute;
   right: 5px;


### PR DESCRIPTION
GitHub Pages automatically assigns element IDs to H tags, so a markdown h2 tag with the text "Search" ends up generating an h2 element _with and id of "search"_. This avoids that conflict by being more specific in the search element ID.