### PR TITLE
Map subsection orders directly to frontmatter-defined value

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -59,7 +59,7 @@
                   {% else %}
                     <li>
                   {% endif %}
-                    <a href="{{item.url}}">{{collection.section_order}}.{{ item.order | minus: 1 }} {{ item.title }}</a>
+                    <a href="{{item.url}}">{{collection.section_order}}.{{ item.order }} {{ item.title }}</a>
                   </li>
                 {% endfor %}
               </ul>


### PR DESCRIPTION
Frontmatter `order` values are no longer reduced by 1 to account for an `index`, which should be set to `order: 0`.

The PEC event microsites will follow this convention from the initial build. ACC content will have to be updated in order to use this and any subsequent versions of the Kocurek theme.